### PR TITLE
Update valkey Shutdown to close connection

### DIFF
--- a/internal/infra/valkey/connection.go
+++ b/internal/infra/valkey/connection.go
@@ -32,7 +32,7 @@ func NewValkeyClient(ctx context.Context, cfg *config.Config) (ValkeyClient, err
 
 // graceful shutdown (e.g., when main.go ends)
 func (v *valkeyClient) Shutdown(ctx context.Context) error {
-	return v.client.Do(ctx, v.client.B().Shutdown().Build()).Error()
+	return v.client.Close()
 }
 
 func (v *valkeyClient) GetValue(ctx context.Context, key string) (string, error) {


### PR DESCRIPTION
## Summary
- update valkey client `Shutdown` to close the client connection

## Testing
- `go test ./...` *(fails: unable to download modules)*

------
https://chatgpt.com/codex/tasks/task_e_685952e9be708325aa7b5040904991b1