### PR TITLE
Add topic entity and return objects

### DIFF
--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -65,7 +65,7 @@ func main() {
 
 	ackTimeout := 30 * time.Second
 	publishSvc := service.NewPublishService(ackDispatcher, ackTimeout, natsRepo, valkeyRepo)
-	topicSvc := service.NewTopicService(natsRepo)
+	topicSvc := service.NewTopicService(natsRepo, cfg)
 
 	// Handler resource create
 	accountBase := handler.AccountBaseHandlers(topicSvc)

--- a/internal/entity/topic.go
+++ b/internal/entity/topic.go
@@ -1,0 +1,5 @@
+package entity
+
+type Topic struct {
+	TopicSrn string `json:"topicSrn"`
+}

--- a/internal/handler/topic.go
+++ b/internal/handler/topic.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"nats/internal/context/logs"
+	"nats/internal/entity"
 	"nats/internal/service"
 	"net/http"
 
@@ -78,10 +79,16 @@ func (h *TopicHandler) List() echo.HandlerFunc {
 		ctx := c.Request().Context()
 		logger := logs.GetLogger(ctx)
 
-		topics, err := h.svc.ListTopics(ctx)
+		accountID := c.Param("accountid")
+		topicObjs, err := h.svc.ListTopics(ctx, accountID)
 		if err != nil {
 			logger.Error("리스트 조회 실패", zap.Error(err))
 			return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		}
+
+		topics := make([]string, len(topicObjs))
+		for i, t := range topicObjs {
+			topics[i] = t.TopicSrn
 		}
 
 		logger.Info("리스트 반환", zap.Int("count", len(topics)))


### PR DESCRIPTION
## Summary
- add `Topic` struct in entity package for SRN representation
- return `[]Topic` from `TopicService`
- adapt handler to convert topic objects back to strings for response
- build topic SRNs with `strings.Builder`

## Testing
- `go test ./...` *(fails: Forbidden to download modules)*

------
https://chatgpt.com/codex/tasks/task_e_685a14e886248325814c3a2948282ccb