### PR TITLE
Add helper for tracing errors

### DIFF
--- a/internal/service/topicService.go
+++ b/internal/service/topicService.go
@@ -64,6 +64,7 @@ func (s *topicService) ListTopics(ctx context.Context, account string) ([]entity
 
 	namesCh, err := s.natsRepo.ListStreamNames(ctx)
 	if err != nil {
+		traces.RecordSpanError(ctx, span, "natsRepo.ListStreamNames error", err)
 		return nil, err
 	}
 


### PR DESCRIPTION
## Summary
- add `RecordSpanError` helper in traces for consistent span error logging
- use `RecordSpanError` when listing topics fails

## Testing
- `go test ./...` *(fails: unable to fetch modules)*

------
https://chatgpt.com/codex/tasks/task_e_685a9b4ca91083258398d9a756dfb02d